### PR TITLE
WiP: Introduce SNI and randomized load-balancing

### DIFF
--- a/_tags
+++ b/_tags
@@ -4,4 +4,4 @@ true : warn(+A-4-6-7-9-40-42-44-48)
 
 <tlstunnel.{ml,byte,native}>: package(tls), package(x509), package(nocrypto), \
   package(lwt), package(cmdliner), package(sexplib), \
-  package(lwt.unix), package(tls.lwt)
+  package(lwt.unix), package(tls.lwt), package(wildcard)


### PR DESCRIPTION
This is a WiP, it would be great to get some comments on the code, and the issues detailed below.

It adds a dependency on the structure used to match requested SNI names with the desired backends. I didn't know if I should also merge that in, so for now it's in a git repo of its own. To test this patch you will need to pin it:
`opam pin add wildcard https://github.com/cfcs/ocaml-wildcard`
NOTE: If it fails to install it, make sure you have `opam install oasis2opam`

This commit introduces two new parameters:

`--sni`: Enable SNI and several `--certificate` / `--key` parameters

`--hostmap`: Configure mapping of SNI hosts to specific backends. If several backends are given, one is randomly selected. This parameter may be specified multiple times.
Example:
`"[domain 1] [domain 2] [..] = [backend:port] [backend2:port]"`

Additionally it allows users to specify multiple `--certificate` / `--key` pairs (introducing argument ordering significance, not sure that's a good thing). See the TODO
## TODO
- This patch currently breaks support for specifying `--certificate` without a corresponding `--key`
- This patch does not check that `--certificate` arguments corresponds to the names passed to `--map`
- This patch does not handle wildcards in `--map`
